### PR TITLE
f - 修复路由设置跳转报错问题

### DIFF
--- a/c3-front/src/app/components/navbar/navbar.directive.js
+++ b/c3-front/src/app/components/navbar/navbar.directive.js
@@ -71,7 +71,7 @@
             };
 
             vm.state = $state;
-            vm.state.params.treeid = vm.state.params.treeid ? vm.state.params.treeid : -1;
+            vm.state.params.treeid = vm.state.params.treeid ? vm.state.params.treeid : 4000000000;
 
             // get user
             $http.get('/api/connector/connectorx/sso/userinfo').success(function(data){

--- a/c3-front/src/app/index.route.js
+++ b/c3-front/src/app/index.route.js
@@ -623,10 +623,11 @@
             })
  
              .state('home.connector.settings', {
-                url: 'settings',
+                url: 'settings/:treeid',
                 templateUrl: 'app/pages/connector/settings/settings.html',
                 controller: 'ConnectorSettingsController',
-                controllerAs: 'connectorsettings'
+                controllerAs: 'connectorsettings',
+                params: {treeid: '4000000000'}
             })
  
              .state('home.connector.mesg', {


### PR DESCRIPTION
f - 修复路由设置跳转报错问题
设置模块跳转不会添加treeid 通过手动添加路由动态参数来进行带参数跳转
当treeid不存在时， 通过动态设置为默认值来达到正常跳转效果
2023-05-11 16:09