### PR TITLE
导航卡片调整 bpm详情调整入口

### DIFF
--- a/c3-front/src/app/components/globalsearch/globalsearch.controller.js
+++ b/c3-front/src/app/components/globalsearch/globalsearch.controller.js
@@ -28,6 +28,9 @@
           swal({ title: '获取菜单失败', text: data.info, type: 'error' });
           vm.cardMenu = []
         }
+      }).catch(err => {
+        vm.searchloadover = false;
+        console.error(err)
       });
     };
     vm.reload();

--- a/c3-front/src/app/components/globalsearch/globalsearch.html
+++ b/c3-front/src/app/components/globalsearch/globalsearch.html
@@ -27,9 +27,10 @@
         </div>
         <div ng-if="globalsearch.cardMenu.length !== 0" ng-repeat="item in globalsearch.cardMenu" class="{{item.url === ''? 'menu-panel-card-disable-items': 'menu-panel-card-items'}}"
           ng-click="globalsearch.handleCardClick(item)">
-          <div class="menu-panel-card-items-icon">
-            <img src="{{!globalsearch.iconMap[item.icon] ? globalsearch.iconMap['bpm']: globalsearch.iconMap[item.icon]}}" />
-
+          <div class="menu-panel-card-items-left">
+            <div class="menu-panel-card-items-icon">
+              <img src="{{!globalsearch.iconMap[item.icon] ? globalsearch.iconMap['bpm']: globalsearch.iconMap[item.icon]}}" />
+            </div>
           </div>
           <div class="menu-panel-card-items-content">
             <div title="{{item.name}}" class="menu-panel-card-items-content-title">{{item.name}}</div>

--- a/c3-front/src/app/components/globalsearch/globalsearch.scss
+++ b/c3-front/src/app/components/globalsearch/globalsearch.scss
@@ -52,9 +52,8 @@ h5 {
 .menu-panel-card {
   margin-top: 50px;
   width: 100%;
-  height: 500px;
-  min-height: 300px;
-  overflow-y: auto;
+  height: 100%;
+  min-height: 500px;
   overflow-x: hidden;
   margin-left: 10px;
   display: flex;
@@ -73,11 +72,11 @@ h5 {
 
   &-items {
     cursor: pointer;
-    width: 250px;
-    height: 120px;
-    margin: 20px;
+    width: 323px;
+    height: 200px;
+    margin: 30px 45px;
     background-color: #fafafa;
-    border-radius: 10px;
+    border-radius: 20px;
     transition: all 0.2s ease-in-out;
     box-shadow: 18px 18px 15px rgba(0, 0, 0, 0.2), -18px -18px 15px rgba(255, 255, 255, 1);
     display: flex;
@@ -91,15 +90,21 @@ h5 {
       box-shadow: 18px 18px 30px rgba(0, 0, 0, 0.2)
     }
 
+    &-left {
+      height: 100%;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
     &-icon {
       background-color: #FF6633;
-      width: 50px;
-      height: 50px;
+      width: 60px;
+      height: 60px;
       min-width: 50px;
       min-height: 50px;
       padding: 10px;
       border-radius: 50%;
-      margin: 20px 20px 20px;
+      margin: 0px 40px;
 
       img {
         width: 100%;
@@ -109,28 +114,29 @@ h5 {
 
 
     &-content {
-      margin-top: 20px;
+      margin-top: 40px;
 
       &-title {
-        font-size: 14px;
+        font-size: 15px;
         padding-right: 20px;
         font-weight: 600;
-        overflow-wrap:break-word;
+        overflow-wrap: break-word;
         word-break: break-word;
       }
 
       &-describe {
-        margin-top: 10px;
+        margin-top: 30px;
         padding-right: 20px;
-        font-size: 12px;
+        font-size: 13px;
         color: #999696;
         height: 36px;
         overflow: hidden;
-        overflow-wrap:break-word;
+        overflow-wrap: break-word;
         word-break: break-word;
       }
     }
   }
+
   &-disable-items {
     cursor: not-allowed;
     width: 250px;
@@ -166,7 +172,7 @@ h5 {
         font-size: 14px;
         padding-right: 20px;
         font-weight: 600;
-        overflow-wrap:break-word;
+        overflow-wrap: break-word;
         word-break: break-word;
       }
 
@@ -177,7 +183,7 @@ h5 {
         color: #999696;
         height: 36px;
         overflow: hidden;
-        overflow-wrap:break-word;
+        overflow-wrap: break-word;
         word-break: break-word;
       }
     }

--- a/c3-front/src/app/pages/history/bpm/bpm.html
+++ b/c3-front/src/app/pages/history/bpm/bpm.html
@@ -86,7 +86,7 @@
             <div class="panel-tabs" ng-init='calltype = { "page":"C3T.页面", "api":"API", "crontab":"C3T.计划任务" }'>
                 <table ng-table="historybpm.data_Table" class="table table-hover text-center table-condensed">
                     <tr ng-repeat="ss in $data">
-                        <td data-title="'C3T.BPM单号'|translate"><a style="cursor: pointer" ng-click="historybpm.taskDetail(ss.uuid)" >{{ss.extid}}</a></td>
+                        <td data-title="'C3T.BPM单号'|translate">{{ss.extid}}</td>
                         <td data-title="'C3T.任务名称'|translate">{{ss.alias}}</td>
                         <td data-title="'C3T.发起人'|translate">{{ss.user}}</td>
                         <td data-title="'C3T.处理人'|translate">{{ss.handler}}</td>

--- a/c3-front/src/app/pages/search/search.controller.js
+++ b/c3-front/src/app/pages/search/search.controller.js
@@ -29,6 +29,9 @@
           swal({ title: '获取菜单失败', text: data.info, type: 'error' });
           vm.cardMenu = []
         }
+      }).catch(err => {
+        vm.searchloadover = false;
+        console.error(err)
       });
     };
     vm.reload();

--- a/c3-front/src/app/pages/search/search.html
+++ b/c3-front/src/app/pages/search/search.html
@@ -19,8 +19,10 @@
         </div>
         <div ng-if="!search.searchloadover && search.cardMenu.length !== 0" ng-repeat="item in search.cardMenu" class="{{item.url === ''? 'menu-panel-card-disable-items': 'menu-panel-card-items'}}"
           ng-click="search.handleCardClick(item)">
-          <div class="menu-panel-card-items-icon">
-            <img src="{{!search.iconMap[item.icon] ? globalsearch.iconMap['bpm'] : search.iconMap[item.icon]}}" />
+          <div class="menu-panel-card-items-left">
+            <div class="menu-panel-card-items-icon">
+              <img src="{{!search.iconMap[item.icon] ? search.iconMap['bpm'] : search.iconMap[item.icon]}}" />
+            </div>
           </div>
           <div class="menu-panel-card-items-content">
             <div title="{{item.name}}" class="menu-panel-card-items-content-title">{{item.name}}</div>

--- a/c3-front/src/app/pages/search/search.scss
+++ b/c3-front/src/app/pages/search/search.scss
@@ -75,11 +75,11 @@ h5 {
 
   &-items {
     cursor: pointer;
-    width: 250px;
-    height: 120px;
-    margin: 20px;
+    width: 323px;
+    height: 200px;
+    margin: 30px 45px;
     background-color: #fafafa;
-    border-radius: 10px;
+    border-radius: 20px;
     transition: all 0.2s ease-in-out;
     box-shadow: 18px 18px 15px rgba(0, 0, 0, 0.2), -18px -18px 15px rgba(255, 255, 255, 1);
     display: flex;
@@ -93,15 +93,21 @@ h5 {
       box-shadow: 18px 18px 30px rgba(0, 0, 0, 0.2)
     }
 
+    &-left {
+      height: 100%;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
     &-icon {
       background-color: #FF6633;
-      width: 50px;
-      height: 50px;
+      width: 60px;
+      height: 60px;
       min-width: 50px;
       min-height: 50px;
       padding: 10px;
       border-radius: 50%;
-      margin: 20px 20px 20px;
+      margin: 0px 40px;
 
       img {
         width: 100%;
@@ -111,10 +117,10 @@ h5 {
 
 
     &-content {
-      margin-top: 20px;
+      margin-top: 40px;
 
       &-title {
-        font-size: 14px;
+        font-size: 15px;
         padding-right: 20px;
         font-weight: 600;
         overflow-wrap: break-word;
@@ -122,9 +128,9 @@ h5 {
       }
 
       &-describe {
-        margin-top: 10px;
+        margin-top: 30px;
         padding-right: 20px;
-        font-size: 12px;
+        font-size: 13px;
         color: #999696;
         height: 36px;
         overflow: hidden;


### PR DESCRIPTION
#### 导航卡片调整  bpm详情入口整合
- 导航卡片样式大小调大， 变得不紧凑
- bpm列表下 点击id跳转测试管理界面关闭， 只留详情按钮跳转详情
- 导航卡片列表接口返回失败时，隐藏掉加载动画
- 2023-05-18 18:36