### PR TITLE
导航管理跳转链接样式调整

### DIFF
--- a/c3-front/src/app/pages/global/navigation/dialog/dialog.html
+++ b/c3-front/src/app/pages/global/navigation/dialog/dialog.html
@@ -26,8 +26,9 @@
       <div class="col-sm-10 form-group">
         <label class="col-sm-3 control-label">URL</label>
         <div class="col-sm-9">
-          <input type="text" class="form-control" name="adduser" placeholder="URL"
-            ng-model="navigationDialog.postdata.url" required>
+          <textarea name="adduser" id="" cols="70" rows="5"  placeholder="URL"  ng-model="navigationDialog.postdata.url" required></textarea>
+          <!-- <input type="text" class="form-control" name="adduser" placeholder="URL"
+            ng-model="navigationDialog.postdata.url" required> -->
         </div>
       </div>
     </div>

--- a/c3-front/src/app/pages/global/navigation/navigation.html
+++ b/c3-front/src/app/pages/global/navigation/navigation.html
@@ -48,7 +48,7 @@
             </td>
 
             <td data-title="'C3T.跳转地址'|translate" width="80" filter="{ url: 'text'}">
-              <div title="{{item.url}}">
+              <div class="line-feed line-feed-min" title="{{item.url}}">
                 {{item.url || '-'}}
               </div>
             </td>

--- a/c3-front/src/app/pages/global/navigation/navigation.scss
+++ b/c3-front/src/app/pages/global/navigation/navigation.scss
@@ -20,9 +20,11 @@
 }
 
 .line-feed {
-  word-break: break-all;
-  max-width: 200px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  white-space: pre-wrap;
+  margin: 0 auto;
+}
+.line-feed-min {
+  min-width: 300px;
+  margin: 0 10px;
+
 }


### PR DESCRIPTION
#### 导航管理跳转链接样式调整
- 导航管理列表的跳转地址显示增加了换行，用于应对链接过长问题
- 新建/编辑弹窗的url地址输入框改为文本框， 当链接过长时 可以全部展示出来