### PR TITLE
前端问题修复

### DIFF
--- a/c3-front/src/app/components/globalsearch/globalsearch.controller.js
+++ b/c3-front/src/app/components/globalsearch/globalsearch.controller.js
@@ -47,7 +47,7 @@
         vm.cardMenu = defaultArr;
         return;
       }
-      vm.cardMenu = defaultArr.filter(item => item.name.includes(vm.choiceSearch));
+      vm.cardMenu = defaultArr.filter(item => item.name.toLowerCase().includes(vm.choiceSearch.toLowerCase()));
     }
 
     vm.handleClear = function () {

--- a/c3-front/src/app/pages/bpm/bpm.html
+++ b/c3-front/src/app/pages/bpm/bpm.html
@@ -304,7 +304,7 @@
                                     <tbody>
                                         <tr ng-repeat="item in bpm.bpmlog[$index+1]" style="cursor: pointer">
                                             <td>{{item.time}}</td>
-                                            <td>{{item.info}}</td>
+                                            <td ng-bind-html="item.info"></td>
                                         </tr>
                                     </tbody>
                                 </table>

--- a/c3-front/src/app/pages/bpm/bpm.html
+++ b/c3-front/src/app/pages/bpm/bpm.html
@@ -147,7 +147,7 @@
                                       </ui-select>
                                       <ui-select ng-model="ss.value" ng-change="bpm.optionxchange(ss.name, ss.value, ss.option)" ng-show="!bpm.isstring(ss.option[0])" style="font-size: 15px;height: 42px" >
                                         <ui-select-match><span class="item-label">{{$select.selected.alias}}</span></ui-select-match>
-                                        <ui-select-choices repeat="item.name as item in ss.option | filter: $select.search">
+                                        <ui-select-choices repeat="item.name as item in ss.option | filter: {alias: $select.search}">
                                             <div ng-bind-html="item.alias | highlight: ss.option"></div>
                                         </ui-select-choices>
                                       </ui-select>
@@ -174,7 +174,7 @@
                                         <ui-select-match>
                                           <span class="item-label">{{$select.selected.alias}}</span>
                                         </ui-select-match>
-                                        <ui-select-choices repeat="item.name as item in bpm.optionx[ss.name] | filter: {name:$select.search}">
+                                        <ui-select-choices repeat="item.name as item in bpm.optionx[ss.name] | filter: {alias:$select.search}">
                                             <div ng-bind-html="item.alias | highlight: $select.search"></div>
                                         </ui-select-choices>
                                       </ui-select>

--- a/c3-front/src/app/pages/search/search.controller.js
+++ b/c3-front/src/app/pages/search/search.controller.js
@@ -47,7 +47,7 @@
         vm.cardMenu = defaultArr;
         return;
       }
-      vm.cardMenu = defaultArr.filter(item => item.name.includes(vm.choiceSearch));
+      vm.cardMenu = defaultArr.filter(item => item.name.toLowerCase().includes(vm.choiceSearch.toLowerCase()));
     }
 
     vm.handleClear = function () {


### PR DESCRIPTION
#### 修复问题
- 修复bpm的工单处理字符串转化为html标签问题 需要在标签添加ng-bind-html属性 并将要展示的字符串进行赋值 即完成转换
- 全局搜索功能支持大小写搜索 现在输入值后 大小写都可以被搜到了
- 修复bpm任务的部分下拉框搜索只能搜索id的问题 现在支持搜索整条alias