### PR TITLE
f - 容器集群应用管理 node管理手动多选操作不生效问题修复

### DIFF
--- a/c3-front/src/app/pages/kubernetesmanage/node.controller.js
+++ b/c3-front/src/app/pages/kubernetesmanage/node.controller.js
@@ -165,7 +165,7 @@
           angular.forEach(vm.tableData, function (item, index, array) {
             vm.checkboxes.items[[array[index].NAME]] = value
           });
-          vm.checkboxes.itemsNumber = Object.keys(vm.checkboxes.items).filter(item => item === true).length
+          vm.checkboxes.itemsNumber = Object.values(vm.checkboxes.items).filter(item => item === true).length
           let nodeList = []
           for (let key in vm.checkboxes.items) {
             nodeList.push(String(key))


### PR DESCRIPTION
#### 修复问题
- 容器集群应用管理 node管理通过单个点击至全选时， 更改获取的判断的值