### PR TITLE
f - CMDB详情列表去掉过滤条件结构的pageSize选项

### DIFF
--- a/c3-front/src/app/pages/device/data/data.controller.js
+++ b/c3-front/src/app/pages/device/data/data.controller.js
@@ -125,7 +125,6 @@
         vm.reload();
 
         vm.pageSizeChange = function (value) {
-          vm.grepdata['pageSize'] = value
           vm.tablePageSize = value
           vm.reload()
         }


### PR DESCRIPTION
#### 修复问题
- CMDB详情列表去掉过滤条件结构的pageSize选项