### PR TITLE
Revert "同步aws ec2资源时，使用主内网ip作为实例的内网ip"

### DIFF
--- a/AGENT/device/conf/template/sync-aws-ec2.yml
+++ b/AGENT/device/conf/template/sync-aws-ec2.yml
@@ -92,7 +92,7 @@ download:
       InstanceId: "实例ID"
       Name: "名称"
       RegionId: "区域"
-      SelectedPrivateIp: "内网IP"
+      PrivateIpAddress: "内网IP"
       PublicIpAddress: "公网IP"
       InstanceType: "实例类型"
       Placement.AvailabilityZone: "所在可用区"

--- a/Connector/pp/cloud/sync/c3mc-cloud-aws-ec2
+++ b/Connector/pp/cloud/sync/c3mc-cloud-aws-ec2
@@ -36,25 +36,6 @@ class Ec2:
             for instance in reservation["Instances"]:
                 instance["RegionId"] = self.region
 
-                private_ip = ""
-                for network_interface in instance["NetworkInterfaces"]:
-                    found = False
-                    for private_addr_info in network_interface["PrivateIpAddresses"]:
-                        if private_addr_info["Primary"]:
-                            private_ip = private_addr_info["PrivateIpAddress"]
-                            found = True
-                            break
-                    if found:
-                        break
-                # 优先使用primary内网ip作为实例的内网ip
-                # 如果找不到primary内网ip则使用默认的PrivateIpAddress
-                if private_ip:
-                    instance["SelectedPrivateIp"] = private_ip
-                elif "PrivateIpAddress" in instance:
-                    instance["SelectedPrivateIp"] = instance["PrivateIpAddress"]
-                else:
-                    instance["SelectedPrivateIp"] = ""
-
                 if "window" in instance["PlatformDetails"].lower():
                     instance["os"] = "Windows"
                 else:


### PR DESCRIPTION
Reverts open-c3/open-c3#888

原来的主ip才是对的。
错误判断了，是其中一个主ip的机器回收了，这个ip被另一个机器复用了，