### PR TITLE
f - 修复下拉框选项过长展示不全问题

### DIFF
--- a/c3-front/src/app/pages/bpm/bpm.html
+++ b/c3-front/src/app/pages/bpm/bpm.html
@@ -343,4 +343,10 @@
       .label-common-style {
         padding-top: 0!important;
       }
+
+      .ui-select-bootstrap .ui-select-choices-row>span  {
+        white-space: wrap;
+        word-break: break-all;
+        overflow-wrap: break-word;
+      }
     </style>

--- a/c3-front/src/app/pages/device/data/data.html
+++ b/c3-front/src/app/pages/device/data/data.html
@@ -189,4 +189,9 @@
     display: inline-block;
     margin: 20px;
   }
+  .ui-select-bootstrap .ui-select-choices-row>span  {
+    white-space: wrap;
+    word-break: break-all;
+    overflow-wrap: break-word;
+  }
 </style>


### PR DESCRIPTION
#### 修复问题 
-  下拉选择框内容过长时  添加换行展示完全
- 涉及修改的模块 BPM工单的下拉选择框 CMDB详情的过滤器选择框