### PR TITLE
f - 导航常用搜索过滤多语言标识

### DIFF
--- a/c3-front/src/app/components/globalsearch/globalsearch.controller.js
+++ b/c3-front/src/app/components/globalsearch/globalsearch.controller.js
@@ -81,10 +81,11 @@
     }
 
     vm.handleFrequentClick = function (selectedItems) {
-      if (vm.choiceSearch === selectedItems) {
+      const newSelectedItem = selectedItems.replace(/C3T./g, '');
+      if (vm.choiceSearch === newSelectedItem) {
         return
       }
-      vm.choiceSearch = selectedItems
+      vm.choiceSearch = newSelectedItem
       vm.buttonSubmit();
     }
 

--- a/c3-front/src/app/pages/search/search.controller.js
+++ b/c3-front/src/app/pages/search/search.controller.js
@@ -92,10 +92,11 @@
     }
 
     vm.handleFrequentClick = function (selectedItems) {
-      if (vm.choiceSearch === selectedItems) {
+      const newSelectedItem = selectedItems.replace(/C3T./g, '');
+      if (vm.choiceSearch === newSelectedItem) {
         return
       }
-      vm.choiceSearch = selectedItems
+      vm.choiceSearch = newSelectedItem
       vm.buttonSubmit();
     }
   }


### PR DESCRIPTION
#### 修复问题
- 搜索模块常用搜索点击时会将多语言标识带入搜索 导致搜索失效 通过正则过滤掉多语言标识来保持正常功能