### PR TITLE
f - BPM模块无法提交工单问题修复

### DIFF
--- a/c3-front/src/app/pages/bpm/bpm.controller.js
+++ b/c3-front/src/app/pages/bpm/bpm.controller.js
@@ -436,7 +436,6 @@
         vm.optionxchange = function (type, stepinfo, stepname, stepvalue, stepoption) {
           // optcheck字段调用接口校验逻辑
           if (type !== 'clear') {
-            vm.errorResult = '加载中';
             const tempName = vm.extname( stepname );
             const sameLevelArr = []
             const varDict = {}
@@ -448,6 +447,7 @@
               }
             });
             if (stepinfo.value_type || stepinfo.optchk) {
+              vm.errorResult = '加载中';
               vm.changeDebounce(varDict, stepinfo, stepname)
             }
             const hasOptChkArr = sameLevelArr.filter(item => item.value_type || item.optchk)


### PR DESCRIPTION
#### 修复问题
- BPM模块无法提交工单问题修复
- 只有在包含value_type或者optchk才去赋值 errorResult 避免不需校验的工单选项也执行赋值逻辑 