### PR TITLE
f - 导航菜单 切换其他菜单时模块菜单未正常展示问题修复

### DIFF
--- a/c3-front/src/app/components/navbar/navbar.directive.js
+++ b/c3-front/src/app/components/navbar/navbar.directive.js
@@ -422,8 +422,9 @@
 
 
           vm.toggleCard = function (type) {
-            if (type) {
+            if (type  === false) {
               vm.isHovered = type
+              return
             }
             vm.isHovered = !vm.isHovered
           }

--- a/c3-front/src/app/components/navbar/navbar.html
+++ b/c3-front/src/app/components/navbar/navbar.html
@@ -330,7 +330,7 @@
         </li> -->
 
 
-        <li class="dropdown nav-padding" uib-dropdown>
+        <li class="dropdown nav-padding" uib-dropdown ng-click="nav.toggleCard(false)">
             <a class="dropdown-toggle ripple" href="javascript:void(0)" uib-dropdown-toggle>
                 <i class="fa fa-language fa-lg"></i>
             </a>
@@ -343,7 +343,7 @@
             </ul>
         </li>
 
-        <li class="dropdown nav-padding" uib-dropdown>
+        <li class="dropdown nav-padding" uib-dropdown ng-click="nav.toggleCard(false)">
             <a href="javascript:void(0)" class="dropdown-toggle fw600 p15 lh30 ripple" uib-dropdown-toggle>
                 <span>{{ nav.user.name }}</span>
                 <span class="caret caret-tp hidden-xs"></span>

--- a/c3-front/src/app/components/navbar/oldnavbar.html
+++ b/c3-front/src/app/components/navbar/oldnavbar.html
@@ -1,3 +1,4 @@
+<!-- C3TODO 230821 该文件为旧版导航菜单文件，待新版本模块菜单稳定后可以删除掉 -->
 <header ng-init='openc3_style_ctrl="openc3";openc3_job_system_only=0' class="navbar navbar-fixed-top bg-danger">
   <div ng-show="!openc3_job_system_only" >
       <div ng-if="openc3_style_ctrl == 'openc3'" class="navbar-branding">


### PR DESCRIPTION
#### 修复问题
- 点击CMDB菜单也会打开模块下拉菜单问题修复
- 点击切换中英文与个人信息时 模块菜单的下拉项不会一起出现
- 旧版菜单导航添加C3TODO注释