### PR TITLE
f - 修复BPM添加项删除时留存问题

### DIFF
--- a/c3-front/src/app/pages/bpm/bpm.controller.js
+++ b/c3-front/src/app/pages/bpm/bpm.controller.js
@@ -800,8 +800,11 @@
             const hasValueType = []
             const hasIpValueType = []
             angular.forEach(vm.valias, function (data, index) {
+              const isExist = $scope.jobVar.some(item => item.name === index)
+              if (isExist) {
                 var aliasname = index + "__alias";
                 varDict[aliasname] = data;
+              }
             });
  
             angular.forEach($scope.jobVar, function (data, index) {
@@ -845,8 +848,11 @@
             var varDict = {};
 
             angular.forEach(vm.valias, function (data, index) {
+              const isExist = $scope.jobVar.some(item => item.name === index)
+              if (isExist) {
                 var aliasname = index + "__alias";
                 varDict[aliasname] = data;
+              }
             });
  
             angular.forEach($scope.jobVar, function (data, index) {


### PR DESCRIPTION
#### 修复问题
- 由于change事件触发时 会先把当前项优先写入varDict对象中 执行删除操作时不会清除掉；在最终提交表单时，使用jobVar数组对象的值进行对比， 过滤掉不存在的项再去提交表单，可以避免这个问题