### PR TITLE
f - 针对华为云资源可用区等信息的获取逻辑进行更新,以及一些bug修复

### DIFF
--- a/Connector/lib/pp/c3mc_cloud_huawei_flavors.py
+++ b/Connector/lib/pp/c3mc_cloud_huawei_flavors.py
@@ -2,32 +2,41 @@
 # -*- coding: utf-8 -*-
 
 import json
-
 from huaweicloudsdkcore.auth.credentials import BasicCredentials
 from huaweicloudsdkecs.v2.region.ecs_region import EcsRegion
 from huaweicloudsdkecs.v2 import *
-
+from huaweicloudsdkcore.exceptions import exceptions
 
 class Flavors:
     def __init__(self, access_id, access_key, project_id, region):
         self.access_id = access_id
         self.access_key = access_key
         self.region = region
-        if project_id in [None, "None"]:
-            self.project_id = None
-        else:
-            self.project_id = project_id.strip()
+        self.project_id = project_id.strip() if project_id not in [None, "None"] else None
         self.client = self.create_client()
 
     def create_client(self):
-        credentials = BasicCredentials(self.access_id, self.access_key, self.project_id)
-
-        return EcsClient.new_builder() \
-        .with_credentials(credentials) \
-        .with_region(EcsRegion.value_of(self.region)) \
-        .build()
+        try:
+            credentials = BasicCredentials(self.access_id, self.access_key, self.project_id)
+            return EcsClient.new_builder() \
+                .with_credentials(credentials) \
+                .with_region(EcsRegion.value_of(self.region)) \
+                .build()
+        except exceptions.ClientRequestException as e:
+            print(f"Warning: Error creating client: {e}")
+            return None
 
     def list_flavors(self):
-        request = ListFlavorsRequest()
-        response = self.client.list_flavors(request)
-        return json.loads(str(response))["flavors"]
+        if self.client is None:
+            print("Warning: Client not initialized. Skipping flavor list.")
+            return []
+
+        try:
+            request = ListFlavorsRequest()
+            response = self.client.list_flavors(request)
+            return json.loads(str(response))["flavors"]
+        except exceptions.ClientRequestException as e:
+            print(f"Warning: Error listing flavors: {e}")
+            if e.error_code == "APIGW.0802":
+                print("The IAM user does not have permission in this region. Skipping flavor list.")
+            return []

--- a/Connector/pp/cloud/c3mc-cloud-control
+++ b/Connector/pp/cloud/c3mc-cloud-control
@@ -82,7 +82,7 @@ else
     my @argv = @ARGV;
 
     my $tplfile = "/data/Software/mydan/Connector/pp/cloud/control/template/$data->{type}.$data->{subtype}.$o{ctrl}.yml";
-    $tplfile = "/data/Software/mydan/Connector/pp/cloud/control/$data->{type}/$data->{subtype}/$o{ctrl}/tpl.yml" if $cmd =~ /\//;
+    $tplfile = "/data/Software/mydan/Connector/pp/cloud/control/$cmd/tpl.yml" if $cmd =~ /\//;
     my $tmpcont = eval{ YAML::XS::LoadFile $tplfile; };
     die "load tpl fail: $@" if $@;
     unless( @argv )

--- a/Connector/pp/cloud/control/conf.yml
+++ b/Connector/pp/cloud/control/conf.yml
@@ -36,13 +36,19 @@ networking.aws-alb:
 networking.aws-nlb:
   # nlb和alb都是都是elbv2类型，因此使用相同的查询方式
   get-backend-servers: networking/aws-alb/get-backend-servers
+  get: networking/aws-alb/get
+  tag-add: networking/aws-alb/tag-add
+  tag-delete: networking/aws-alb/tag-delete
 networking.aws-elb:
   get-backend-servers: networking/aws-elb/get-backend-servers
   get: networking/aws-elb/get
   tag-add: networking/aws-elb/tag-add
   tag-delete: networking/aws-elb/tag-delete
 networking.aws-globalaccelerator:
+  get: networking/aws-globalaccelerator/get
   get-backend-servers: networking/aws-globalaccelerator/get-backend-servers
+  tag-add: networking/aws-globalaccelerator/tag-add
+  tag-delete: networking/aws-globalaccelerator/tag-delete
 database.aws-dynamodb:
   get: database/aws-dynamodb/get
   tag-add: database/aws-dynamodb/tag-add
@@ -161,3 +167,4 @@ storage.google-vm-volume:
   get: storage/google-vm-volume/get
   tag-add: storage/google-vm-volume/tag-add
   tag-delete: storage/google-vm-volume/tag-delete
+

--- a/Connector/pp/cloud/sync/c3mc-cloud-huawei-ecs
+++ b/Connector/pp/cloud/sync/c3mc-cloud-huawei-ecs
@@ -4,39 +4,75 @@
 import sys
 import json
 
-from huaweicloudsdkcore.auth.credentials import BasicCredentials
+from huaweicloudsdkcore.auth.credentials import GlobalCredentials, BasicCredentials
 from huaweicloudsdkecs.v2.region.ecs_region import EcsRegion
 from huaweicloudsdkecs.v2 import *
+from huaweicloudsdkiam.v3 import *
 
 sys.path.append("/data/Software/mydan/Connector/lib/pp")
 from c3mc_cloud_huawei_vpc import Vpc
 from c3mc_cloud_huawei_flavors import Flavors
 from c3mc_utils import sleep_time_for_limiting
 
-
 max_times_for_get_ecs = 20
 max_times_for_get_vpc = 20
-
 
 class Ecs:
     def __init__(self, access_id, access_key, project_id, region):
         self.access_id = access_id
         self.access_key = access_key
-        self.project_id = None if project_id == "None" else project_id.strip()
         self.region = region
+        self.project_id = project_id if project_id not in [None, "None"] else self.get_project_id()
         self.page_number = 1
         self.page_size = 25
-
         self.client = self.create_client()
 
-    def create_client(self):
-        credentials = BasicCredentials(self.access_id, self.access_key, self.project_id)
-        return (
-            EcsClient.new_builder()
-            .with_credentials(credentials)
-            .with_region(EcsRegion.value_of(self.region))
+    def get_project_id(self):
+        # 定义 IAM 端点映射
+        iam_endpoints = {
+            "eu-west-101": "https://iam.myhuaweicloud.eu",  # 都柏林地区
+            "default": "https://iam.myhuaweicloud.com"  # 默认端点
+        }
+
+        # 选择合适的 IAM 端点
+        iam_endpoint = iam_endpoints.get(self.region, iam_endpoints["default"])
+
+        credentials = GlobalCredentials(self.access_id, self.access_key)
+        iam_client = IamClient.new_builder() \
+            .with_credentials(credentials) \
+            .with_endpoint(iam_endpoint) \
             .build()
-        )
+
+        try:
+            request = KeystoneListProjectsRequest()
+            response = iam_client.keystone_list_projects(request)
+            for project in response.projects:
+                if project.name == self.region:
+                    return project.id
+
+            raise Exception(f"No project found for region {self.region}")
+        except exceptions.ClientRequestException as e:
+            print(f"Failed to get project ID: {e}")
+            sys.exit(1)
+
+    def get_endpoint(self, region_id):
+        # 处理都柏林地区的特殊情况
+        if region_id == "eu-west-101":
+            return f"https://ecs.{region_id}.myhuaweicloud.eu"
+        
+        return f"https://ecs.{region_id}.myhuaweicloud.com"
+
+    def create_client(self):
+        try:
+            credentials = BasicCredentials(self.access_id, self.access_key, self.project_id)
+            endpoint = self.get_endpoint(self.region)
+            return EcsClient.new_builder() \
+                .with_credentials(credentials) \
+                .with_endpoint(endpoint) \
+                .build()
+        except exceptions.ClientRequestException as e:
+            print(f"Warning: Error creating client: {e}")
+            return None
 
     def set_request(self):
         return ListServersDetailsRequest(offset=self.page_number, limit=self.page_size)

--- a/Connector/pp/cloud/sync/c3mc-cloud-huawei-elb
+++ b/Connector/pp/cloud/sync/c3mc-cloud-huawei-elb
@@ -4,25 +4,63 @@
 import sys
 import json
 
-from huaweicloudsdkcore.auth.credentials import BasicCredentials
+from huaweicloudsdkcore.auth.credentials import GlobalCredentials, BasicCredentials
+from huaweicloudsdkcore.region.region import Region
 from huaweicloudsdkelb.v3.region.elb_region import ElbRegion
 from huaweicloudsdkelb.v3 import *
+from huaweicloudsdkiam.v3 import *
 
 
 class Elb:
     def __init__(self, access_id, access_key, project_id, region):
         self.access_id = access_id
         self.access_key = access_key
-        self.project_id = None if project_id == "None" else project_id.strip()
         self.region = region
+        self.project_id = project_id if project_id not in [None, "None"] else self.get_project_id()
         self.client = self.create_client()
+
+    def get_project_id(self):
+        # 定义 IAM 端点映射
+        iam_endpoints = {
+            "eu-west-101": "https://iam.myhuaweicloud.eu",  # 都柏林地区
+            "default": "https://iam.myhuaweicloud.com"  # 默认端点
+        }
+
+        # 选择合适的 IAM 端点
+        iam_endpoint = iam_endpoints.get(self.region, iam_endpoints["default"])
+
+        credentials = GlobalCredentials(self.access_id, self.access_key)
+        iam_client = IamClient.new_builder() \
+            .with_credentials(credentials) \
+            .with_endpoint(iam_endpoint) \
+            .build()
+
+        try:
+            request = KeystoneListProjectsRequest()
+            response = iam_client.keystone_list_projects(request)
+            for project in response.projects:
+                if project.name == self.region:
+                    return project.id
+
+            raise Exception(f"No project found for region {self.region}")
+        except exceptions.ClientRequestException as e:
+            print(f"Failed to get project ID: {e}")
+            sys.exit(1)
+
+    def get_endpoint(self, region_id):
+        # 处理都柏林地区的特殊情况
+        if region_id == "eu-west-101":
+            return f"https://elb.{region_id}.myhuaweicloud.eu"
+        
+        return f"https://elb.{region_id}.myhuaweicloud.com"
 
     def create_client(self):
         credentials = BasicCredentials(self.access_id, self.access_key, self.project_id)
+        endpoint = self.get_endpoint(self.region)
         return (
-            ElbClient.new_builder()
-            .with_credentials(credentials)
-            .with_region(ElbRegion.value_of(self.region))
+            ElbClient.new_builder() \
+            .with_credentials(credentials) \
+            .with_endpoint(endpoint) \
             .build()
         )
 
@@ -57,7 +95,6 @@ def main(access_id, access_key, project_id, region):
             return
         print(f"同步华为云elb资源出错. access_id: {access_id}, region: {region}", file=sys.stderr)
         raise e
-
 
 if __name__ == "__main__":
     main(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4])

--- a/Connector/pp/cloud/sync/c3mc-cloud-huawei-kafka
+++ b/Connector/pp/cloud/sync/c3mc-cloud-huawei-kafka
@@ -4,26 +4,61 @@
 import sys
 import json
 
-from huaweicloudsdkcore.auth.credentials import BasicCredentials
+from huaweicloudsdkcore.auth.credentials import GlobalCredentials, BasicCredentials
 from huaweicloudsdkkafka.v2.region.kafka_region import KafkaRegion
 from huaweicloudsdkkafka.v2 import *
-
+from huaweicloudsdkiam.v3 import *
 
 class Kafka:
     def __init__(self, access_id, access_key, project_id, region):
         self.access_id = access_id
         self.access_key = access_key
-        self.project_id = None if project_id == "None" else project_id.strip()
         self.region = region
-
+        self.project_id = project_id if project_id not in [None, "None"] else self.get_project_id()
         self.client = self.create_client()
+
+    def get_project_id(self):
+        # 定义 IAM 端点映射
+        iam_endpoints = {
+            "eu-west-101": "https://iam.myhuaweicloud.eu",  # 都柏林地区
+            "default": "https://iam.myhuaweicloud.com"  # 默认端点
+        }
+
+        # 选择合适的 IAM 端点
+        iam_endpoint = iam_endpoints.get(self.region, iam_endpoints["default"])
+
+        credentials = GlobalCredentials(self.access_id, self.access_key)
+        iam_client = IamClient.new_builder() \
+            .with_credentials(credentials) \
+            .with_endpoint(iam_endpoint) \
+            .build()
+
+        try:
+            request = KeystoneListProjectsRequest()
+            response = iam_client.keystone_list_projects(request)
+            for project in response.projects:
+                if project.name == self.region:
+                    return project.id
+
+            raise Exception(f"No project found for region {self.region}")
+        except exceptions.ClientRequestException as e:
+            print(f"Failed to get project ID: {e}")
+            sys.exit(1)
+
+    def get_endpoint(self, region_id):
+        # 处理都柏林地区的特殊情况
+        if region_id == "eu-west-101":
+            return f"https://dms.{region_id}.myhuaweicloud.eu"
+        
+        return f"https://dms.{region_id}.myhuaweicloud.com"
 
     def create_client(self):
         credentials = BasicCredentials(self.access_id, self.access_key, self.project_id)
+        endpoint = self.get_endpoint(self.region)
         return (
-            KafkaClient.new_builder()
-            .with_credentials(credentials)
-            .with_region(KafkaRegion.value_of(self.region))
+            KafkaClient.new_builder() \
+            .with_credentials(credentials) \
+            .with_endpoint(endpoint) \
             .build()
         )
 
@@ -39,7 +74,6 @@ class Kafka:
         data_list = self.list_instances()
         for item in data_list:
             print(json.dumps(item, default=str))
-
 
 # project_id 可以命令行传 None
 def main(access_id, access_key, project_id, region):
@@ -60,7 +94,6 @@ def main(access_id, access_key, project_id, region):
             return
         print(f"同步华为云kafka资源出错. access_id: {access_id}, region: {region}", file=sys.stderr)
         raise e
-
 
 if __name__ == "__main__":
     main(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4])

--- a/Connector/pp/cloud/sync/c3mc-cloud-huawei-rds
+++ b/Connector/pp/cloud/sync/c3mc-cloud-huawei-rds
@@ -4,28 +4,63 @@
 import sys
 import json
 
-from huaweicloudsdkcore.auth.credentials import BasicCredentials
+from huaweicloudsdkcore.auth.credentials import GlobalCredentials, BasicCredentials
 from huaweicloudsdkrds.v3.region.rds_region import RdsRegion
 from huaweicloudsdkrds.v3 import *
-
+from huaweicloudsdkiam.v3 import *
 
 class Rds:
     def __init__(self, access_id, access_key, project_id, region):
         self.access_id = access_id
         self.access_key = access_key
-        self.project_id = None if project_id == "None" else project_id.strip()
         self.region = region
+        self.project_id = project_id if project_id not in [None, "None"] else self.get_project_id()
         self.offset = 0
         self.page_size = 25
-
         self.client = self.create_client()
+
+    def get_project_id(self):
+        # 定义 IAM 端点映射
+        iam_endpoints = {
+            "eu-west-101": "https://iam.myhuaweicloud.eu",  # 都柏林地区
+            "default": "https://iam.myhuaweicloud.com"  # 默认端点
+        }
+
+        # 选择合适的 IAM 端点
+        iam_endpoint = iam_endpoints.get(self.region, iam_endpoints["default"])
+
+        credentials = GlobalCredentials(self.access_id, self.access_key)
+        iam_client = IamClient.new_builder() \
+            .with_credentials(credentials) \
+            .with_endpoint(iam_endpoint) \
+            .build()
+
+        try:
+            request = KeystoneListProjectsRequest()
+            response = iam_client.keystone_list_projects(request)
+            for project in response.projects:
+                if project.name == self.region:
+                    return project.id
+
+            raise Exception(f"No project found for region {self.region}")
+        except exceptions.ClientRequestException as e:
+            print(f"Failed to get project ID: {e}")
+            sys.exit(1)
+
+    def get_endpoint(self, region_id):
+        # 处理都柏林地区的特殊情况
+        if region_id == "eu-west-101":
+            return f"https://rds.{region_id}.myhuaweicloud.eu"
+        
+        return f"https://rds.{region_id}.myhuaweicloud.com"
 
     def create_client(self):
         credentials = BasicCredentials(self.access_id, self.access_key, self.project_id)
+        endpoint = self.get_endpoint(self.region)
         return (
-            RdsClient.new_builder()
-            .with_credentials(credentials)
-            .with_region(RdsRegion.value_of(self.region))
+            RdsClient.new_builder() \
+            .with_credentials(credentials) \
+            .with_endpoint(endpoint) \
             .build()
         )
 
@@ -58,7 +93,6 @@ class Rds:
             self.offset = cur_page_number * self.page_size
             self.show()
 
-
 # project_id 可以命令行传 None
 def main(access_id, access_key, project_id, region):
     try:
@@ -70,7 +104,6 @@ def main(access_id, access_key, project_id, region):
             return
         print(f"同步华为云rds资源出错. access_id: {access_id}, region: {region}", file=sys.stderr)
         raise e
-
 
 if __name__ == "__main__":
     main(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4])

--- a/Connector/pp/cloud/sync/c3mc-cloud-huawei-redis
+++ b/Connector/pp/cloud/sync/c3mc-cloud-huawei-redis
@@ -4,34 +4,68 @@
 import sys
 import json
 
-from huaweicloudsdkcore.auth.credentials import BasicCredentials
+from huaweicloudsdkcore.auth.credentials import GlobalCredentials, BasicCredentials
 from huaweicloudsdkdcs.v2.region.dcs_region import DcsRegion
 from huaweicloudsdkdcs.v2 import *
+from huaweicloudsdkiam.v3 import *
 
 sys.path.append("/data/Software/mydan/Connector/lib/pp")
 from c3mc_utils import sleep_time_for_limiting
 
-
 max_times_for_get_redis = 16
-
 
 class Redis:
     def __init__(self, access_id, access_key, project_id, region):
         self.access_id = access_id
         self.access_key = access_key
-        self.project_id = None if project_id == "None" else project_id.strip()
         self.region = region
+        self.project_id = project_id if project_id not in [None, "None"] else self.get_project_id()
         self.offset = 0
         self.page_size = 25
-
         self.client = self.create_client()
+
+    def get_project_id(self):
+        # 定义 IAM 端点映射
+        iam_endpoints = {
+            "eu-west-101": "https://iam.myhuaweicloud.eu",  # 都柏林地区
+            "default": "https://iam.myhuaweicloud.com"  # 默认端点
+        }
+
+        # 选择合适的 IAM 端点
+        iam_endpoint = iam_endpoints.get(self.region, iam_endpoints["default"])
+
+        credentials = GlobalCredentials(self.access_id, self.access_key)
+        iam_client = IamClient.new_builder() \
+            .with_credentials(credentials) \
+            .with_endpoint(iam_endpoint) \
+            .build()
+
+        try:
+            request = KeystoneListProjectsRequest()
+            response = iam_client.keystone_list_projects(request)
+            for project in response.projects:
+                if project.name == self.region:
+                    return project.id
+
+            raise Exception(f"No project found for region {self.region}")
+        except exceptions.ClientRequestException as e:
+            print(f"Failed to get project ID: {e}")
+            sys.exit(1)
+
+    def get_endpoint(self, region_id):
+        # 处理都柏林地区的特殊情况
+        if region_id == "eu-west-101":
+            return f"https://dcs.{region_id}.myhuaweicloud.eu"
+        
+        return f"https://dcs.{region_id}.myhuaweicloud.com"
 
     def create_client(self):
         credentials = BasicCredentials(self.access_id, self.access_key, self.project_id)
+        endpoint = self.get_endpoint(self.region)
         return (
-            DcsClient.new_builder()
-            .with_credentials(credentials)
-            .with_region(DcsRegion.value_of(self.region))
+            DcsClient.new_builder() \
+            .with_credentials(credentials) \
+            .with_endpoint(endpoint) \
             .build()
         )
 
@@ -66,7 +100,6 @@ class Redis:
             self.show()
             sleep_time_for_limiting(max_times_for_get_redis)
 
-
 # project_id 可以命令行传 None
 def main(access_id, access_key, project_id, region):
     try:
@@ -78,7 +111,6 @@ def main(access_id, access_key, project_id, region):
             return
         print(f"同步华为云redis资源出错. access_id: {access_id}, region: {region}", file=sys.stderr)
         raise e
-
 
 if __name__ == "__main__":
     main(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4])

--- a/Connector/pp/cloud/update-account-config/c3mc-cloud-huawei-region-list
+++ b/Connector/pp/cloud/update-account-config/c3mc-cloud-huawei-region-list
@@ -2,11 +2,15 @@
 # -*- coding: utf-8 -*-
 
 import sys
-import requests
-from bs4 import BeautifulSoup
-
-sys.path.append("/data/Software/mydan/Connector/lib/pp")
-
+from huaweicloudsdkcore.auth.credentials import BasicCredentials
+from huaweicloudsdkcore.exceptions import exceptions
+from huaweicloudsdkiam.v3 import *
+from huaweicloudsdkecs.v2 import *
+from huaweicloudsdkelb.v3 import *
+from huaweicloudsdkdns.v2 import *
+from huaweicloudsdkrds.v3 import *
+from huaweicloudsdkdcs.v2 import *
+from huaweicloudsdkkafka.v2 import *
 
 class Huawei:
     def __init__(self, access_id, access_key, iam_user_id, resource_type):
@@ -14,92 +18,217 @@ class Huawei:
         self.access_key = access_key
         self.iam_user_id = iam_user_id
         self.resource_type = resource_type
-        self.huawei_webpage = self.get_huawei_webpage()
-        self.project_region_list = self.get_project_region_list()
-    
+        self.regions = self.get_regions_and_projects()
 
-    def get_huawei_webpage(self):
-        # 华为云目前没有可以直接查询区域列表的接口, 这里使用爬虫从华为云官网文档获取区域
-        #url = 'https://developer.huaweicloud.com/endpoint?all'
-        url = 'http://OPENC3_SERVER_IP:38080/huawei-endpoint.html'
-        response = requests.get(url)
-        response.encoding = 'utf-8'
-        return response.text
-
-
-    def get_project_region_list(self):
-        from c3mc_cloud_huawei_iam import HuaweiIam
-
-        project_region_list = []
-        official_ecs_region_list = self.list_webpage_regions("弹性云服务 ECS")
-        for region in official_ecs_region_list:
+    def get_regions_and_projects(self):
+        credentials = BasicCredentials(self.access_id, self.access_key)
+        
+        # 尝试不同的 endpoint
+        endpoints = [
+            "https://iam.myhuaweicloud.com", 
+            "https://iam.eu-west-101.myhuaweicloud.eu" 
+        ]
+        
+        for endpoint in endpoints:
             try:
-                project_list = HuaweiIam(
-                    self.access_id, self.access_key, region).list_projects()
-                project_region_list.extend(
-                    project.name for project in project_list if project.name not in ["cn-north-1", "cn-east-2"])
-                return project_region_list
-            except Exception as e:
+                iam_client = IamClient.new_builder() \
+                    .with_credentials(credentials) \
+                    .with_endpoint(endpoint) \
+                    .build()
+
+                request = KeystoneListProjectsRequest()
+                response = iam_client.keystone_list_projects(request)
+
+                region_project_map = {}
+                
+                for project in response.projects:
+                    if project.name not in ['MOS','as-south-0','na-east-0']:
+                        region_project_map[project.name] = project.id
+                
+                return region_project_map
+            
+            except exceptions.ClientRequestException as e:
                 continue
-        return project_region_list
+        
+        return {}
 
-    def list_webpage_regions(self, title):
-        soup = BeautifulSoup(self.huawei_webpage, 'html.parser')
-        target_div = soup.find('div', string=title)
-        parent = target_div.find_parent()
-        target_table = parent.find('table')
+    def get_endpoint(self, service, region_id):
+        # 处理都柏林地区的特殊情况
+        if region_id == "eu-west-101":
+            return f"https://{service}.{region_id}.myhuaweicloud.eu"
+        
+        return f"https://{service}.{region_id}.myhuaweicloud.com"
 
-        result = []
-        for row in target_table.find_all('tr'):
-            i = 0
-            for cell in row.find_all('td'):
-                if i == 1:
-                    result.append(cell.text)
-                    break
-                i += 1
-        return sorted(result)
+    def get_ecs_availability_zones(self):
+        ecs_zones = set()
+        
+        for region, project_id in self.regions.items():
+            credentials = BasicCredentials(self.access_id, self.access_key, project_id)
+            try:
+                endpoint = self.get_endpoint('ecs', region)
+                client = EcsClient.new_builder() \
+                    .with_credentials(credentials) \
+                    .with_endpoint(endpoint) \
+                    .build()
+                
+                request = NovaListAvailabilityZonesRequest()
+                response = client.nova_list_availability_zones(request)
 
-    def list_regions(self, title):
-        webpage_region_list = self.list_webpage_regions(title)
-        intersection = set(self.project_region_list) & set(webpage_region_list)
-        return sorted(list(intersection))
+                for zone_info in response.availability_zone_info:
+                    if zone_info.zone_state.available:
+                        ecs_zones.add(f"{region}")
+
+            except exceptions.ClientRequestException as e:
+                pass
+
+        return list(ecs_zones)
+
+    def get_elb_availability_zones(self):
+        elb_zones = set()
+        for region, project_id in self.regions.items():
+            credentials = BasicCredentials(self.access_id, self.access_key, project_id)
+            try:
+                endpoint = self.get_endpoint('elb', region)
+                client = ElbClient.new_builder() \
+                    .with_credentials(credentials) \
+                    .with_endpoint(endpoint) \
+                    .build()
+
+                request = ListAvailabilityZonesRequest()
+                response = client.list_availability_zones(request)
+
+                for zone_list in response.availability_zones:
+                    for zone in zone_list:
+                        if zone.state == "ACTIVE":  
+                            elb_zones.add(f"{region}")
+
+            except exceptions.ClientRequestException as e:
+                pass
+
+        return list(elb_zones)
+
+    def get_dns_availability_zones(self):
+        dns_zones = set()
+
+        for region, project_id in self.regions.items():
+            credentials = BasicCredentials(self.access_id, self.access_key, project_id)
+            try:
+                endpoint = self.get_endpoint('dns', region)
+                client = DnsClient.new_builder() \
+                    .with_credentials(credentials) \
+                    .with_endpoint(endpoint) \
+                    .build()
+
+                request = ListPrivateZonesRequest()
+                request.type = "private"
+                response = client.list_private_zones(request)
+
+                for zone in response.zones:
+                    if zone.status == "ACTIVE":
+                        for router in zone.routers:
+                            if router.status == "ACTIVE":
+                                dns_zones.add(router.router_region)
+
+            except exceptions.ClientRequestException as e:
+                pass
+
+        return list(dns_zones)
+
+    def get_rds_availability_zones(self):
+        rds_zones = set()
+
+        for region, project_id in self.regions.items():
+            credentials = BasicCredentials(self.access_id, self.access_key, project_id)
+            try:
+                endpoint = self.get_endpoint('rds', region)
+                client = RdsClient.new_builder() \
+                    .with_credentials(credentials) \
+                    .with_endpoint(endpoint) \
+                    .build()
+
+                request = ListInstancesRequest()
+                response = client.list_instances(request)
+
+                if response.total_count:
+                    rds_zones.add(f"{region}")
+
+            except exceptions.ClientRequestException as e:
+                pass
+
+        return list(rds_zones)
+
+    def get_dcs_availability_zones(self):
+        dcs_zones = set()
+
+        for region, project_id in self.regions.items():
+            credentials = BasicCredentials(self.access_id, self.access_key, project_id)
+            try:
+                endpoint = self.get_endpoint('dcs', region)
+                client = DcsClient.new_builder() \
+                    .with_credentials(credentials) \
+                    .with_endpoint(endpoint) \
+                    .build()
+
+                request = ListAvailableZonesRequest()
+                response = client.list_available_zones(request)
+
+                for zone in response.available_zones:
+                    if zone.resource_availability:  
+                        dcs_zones.add(f"{region}")
+
+            except exceptions.ClientRequestException as e:
+                pass
+
+        return list(dcs_zones)
+
+    def get_dms_availability_zones(self):
+        dms_zones = set()
+        for region, project_id in self.regions.items():
+            credentials = BasicCredentials(self.access_id, self.access_key, project_id)
+            try:
+                endpoint = self.get_endpoint('dms', region)
+                client = KafkaClient.new_builder() \
+                    .with_credentials(credentials) \
+                    .with_endpoint(endpoint) \
+                    .build()
+
+                request = ListAvailableZonesRequest()
+                response = client.list_available_zones(request)
+
+                for zone in response.available_zones:
+                    if zone.resource_availability:  
+                        dms_zones.add(f"{region}")
+
+            except exceptions.ClientRequestException as e:
+                pass
+
+        return list(dms_zones)
 
     def display(self):
-        regions = []
-
-        if self.resource_type == "dds":
-            regions = self.list_regions("文档数据库服务 DDS")
-        elif self.resource_type == "ecs":
-            regions = self.list_regions("弹性云服务 ECS")
-        elif self.resource_type == "ecs-volume":
-            regions = self.list_regions("云硬盘 EVS")
-        elif self.resource_type == "elb":
-            regions = self.list_regions("弹性负载均衡 ELB")
-        elif self.resource_type == "nosql":
-            regions = self.list_regions("云数据库 GaussDB NoSQL")
-        elif self.resource_type == "obs":
-            # obs属于全局资源，通过每个区域都可以拉取到所有其他区域的obs资源
-            # 为了避免重复拉取资源，下面regions数组只保留一个元素
-            # regions = self.list_regions("对象存储服务 OBS")
-            regions = ["cn-north-4"]
-        elif self.resource_type == "rds":
-            regions = self.list_regions("云数据库 RDS")
-        elif self.resource_type == "redis":
-            regions = self.list_regions("分布式缓存服务 Redis")
-        elif self.resource_type == "kafka":
-            regions = self.list_regions("分布式消息服务 DMS")
-        elif self.resource_type == "dns":
-            regions = self.list_regions("云解析服务 DNS")
-        else:
-            raise RuntimeError("不支持的资源类型")
+        global_resources = ["obs"]
         
+        if self.resource_type in global_resources:
+            regions = [list(self.regions.keys())[0]] if self.regions.keys() else [] 
+        elif self.resource_type == "ecs":
+            regions = self.get_ecs_availability_zones()
+        elif self.resource_type == "elb":
+            regions = self.get_elb_availability_zones()
+        elif self.resource_type == "dns":
+            regions = self.get_dns_availability_zones()
+        elif self.resource_type == "rds":
+            regions = self.get_rds_availability_zones()
+        elif self.resource_type == "redis":
+            regions = self.get_dcs_availability_zones()
+        elif self.resource_type == "kafka":
+            regions = self.get_dms_availability_zones()
+        else:
+            regions = list(self.regions.keys())
+
         for region in regions:
             print(region)
 
-
 def main(access_id, access_key, iam_user_id, resource_type):
     Huawei(access_id, access_key, iam_user_id, resource_type).display()
-
 
 if __name__ == '__main__':
     main(sys.argv[1], sys.argv[2], sys.argv[5], sys.argv[6])


### PR DESCRIPTION
1. 更新了可用区的获取逻辑，通过IAM接口获取账号全部可用区
2. 创建云资源的client 的时候，直接传入endpoint ，避免出现 sdk region 文件里面没有该地区导致报错的问题
3. 修复了重复获取华为云dns 公网域名解析记录的问题
4. 更新 c3mc-cloud-control 脚本的判断逻辑，aws-nlb 可以复用 aws-alb 的功能脚本