### PR TITLE
bpm申请权限流程增加重试&ips检查&过滤掉澳州区域V2.6.0

### DIFF
--- a/Connector/pp/bl/c3mc-base-bastion
+++ b/Connector/pp/bl/c3mc-base-bastion
@@ -4,6 +4,9 @@
 import argparse
 import sys
 import subprocess
+import time
+import traceback
+
 
 
 sys.path.append("/data/Software/mydan/Connector/lib/pp")
@@ -31,35 +34,55 @@ def main():
 
     bl_mode = subprocess.getoutput("c3mc-sys-ctl sys.bl.mode").strip()
 
-    if args.operate_type == "getlist":
-        output = safe_run_command([
-            f"c3mc-base-bastion-getlist-{bl_mode}",
-            args.email
-        ])
-        print(output)
+    # 增加重试5次，解决代理超时问题
+    for i in range(6):
+        try:
+            if args.operate_type == "getlist":
+                code, output, err = safe_run_command_v2(
+                    [
+                        f"c3mc-base-bastion-getlist-{bl_mode}",
+                        args.email,
+                    ]
+                )
+                if code != 0:
+                    raise RuntimeError(err)
+                print(output)
 
-    elif args.operate_type == "addauth":
-        code, output, err = safe_run_command_v2([
-            f"c3mc-base-bastion-addauth-{bl_mode}",
-            args.auth_add_type,
-            args.username,
-            args.email,
-            args.ip,
-            str(args.sudo_hours),
-            args.is_audit
-        ])
-        print(output)
-        if code != 0:
-            exit(1)
-    
-    elif args.operate_type == "adduser":
-        output = safe_run_command([
-            f"c3mc-base-bastion-adduser-{bl_mode}",
-            args.username,
-            args.email,
-        ])
-        print(output)
+            elif args.operate_type == "addauth":
+                code, output, err = safe_run_command_v2(
+                    [
+                        f"c3mc-base-bastion-addauth-{bl_mode}",
+                        args.auth_add_type,
+                        args.username,
+                        args.email,
+                        args.ip,
+                        str(args.sudo_hours),
+                        args.is_audit,
+                    ]
+                )
+                if code != 0:
+                    raise RuntimeError(err)
+                print(output)
+
+            elif args.operate_type == "adduser":
+                code, output, err = safe_run_command_v2(
+                    [
+                        f"c3mc-base-bastion-adduser-{bl_mode}",
+                        args.username,
+                        args.email,
+                    ]
+                )
+                if code != 0:
+                    raise RuntimeError(err)
+                print(output)
+
+            break
+        except Exception:
+            if i == 5:
+                raise Exception(str(traceback.format_exc()))
+
+            time.sleep(5)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/Connector/pp/bl/c3mc-base-bastion-addauth-qizhi
+++ b/Connector/pp/bl/c3mc-base-bastion-addauth-qizhi
@@ -86,7 +86,7 @@ def main(add_type, username, email, ip, sudo_hours, is_audit):
         
         api_addr = urljoin(proxy_addr.strip(), "/run")
         res = requests.request(
-            "POST", api_addr, headers=headers, data=json.dumps(request_data))
+            "POST", api_addr, headers=headers, data=json.dumps(request_data), timeout=1800)
         
         print(f"请求代理地址 {proxy_addr}")
         print(f"请求代理时, 调用的参数为: {json.dumps(request_data)}")

--- a/Connector/pp/bl/c3mc-base-bastion-adduser-qizhi
+++ b/Connector/pp/bl/c3mc-base-bastion-adduser-qizhi
@@ -33,7 +33,7 @@ def main(username, email):
     if app_key != "":
         headers["app_key"] = app_key
 
-    response = requests.request("POST", api_addr, headers=headers, data=json.dumps(request_data))
+    response = requests.request("POST", api_addr, headers=headers, data=json.dumps(request_data), timeout=1800)
     print(json.dumps(response.json()))
 
 

--- a/Connector/pp/bl/c3mc-base-bastion-getlist-qizhi
+++ b/Connector/pp/bl/c3mc-base-bastion-getlist-qizhi
@@ -86,7 +86,7 @@ class CheckUserIps:
             "st-auth-token": self.token,
         }
 
-        response = requests.get(url, headers=headers, params=params)
+        response = requests.get(url, headers=headers, params=params, timeout=1800)
         return response.json()
     
     def display(self, email):

--- a/Connector/pp/bpm/common_option/c3mc-bpm-option-server-auth-check-if-params-valid
+++ b/Connector/pp/bpm/common_option/c3mc-bpm-option-server-auth-check-if-params-valid
@@ -22,8 +22,16 @@ def check_ip_list_in_cmdb(ip_list):
 
     missing_ips = [ip for ip in ip_list if ip not in ip_list_set]
     if missing_ips:
-        print(f"无法从cmdb找到ip: {' '.join(missing_ips)}")
-        exit(0)
+        # 缓存中找不到的ip从cmdb中重新找一遍
+        all_output = safe_run_command(["c3mc-device-api-jumpserver", "--json", "--ips", ",".join(missing_ips)])
+        all_data_list = json.loads(all_output)
+        all_ip_list_set = {item["inIP"] for item in all_data_list} | {
+            item["exIP"] for item in all_data_list
+        }
+        error_ips = [ip for ip in missing_ips if ip not in all_ip_list_set]
+        if error_ips: 
+            print(f"无法从cmdb找到ip: {' '.join(error_ips)}")
+            exit(0)
 
 
 def check_email(email):

--- a/Connector/pp/cloud/update-account-config/c3mc-cloud-aliyun-region-list
+++ b/Connector/pp/cloud/update-account-config/c3mc-cloud-aliyun-region-list
@@ -60,6 +60,9 @@ class Aliyun:
             if self.resource_type == "vpc":
                 regions = list(filter(lambda x: x not in ["ap-northeast-2","ap-southeast-3","ap-southeast-5","ap-southeast-6","cn-fuzhou","cn-guangzhou","cn-heyuan","cn-nanjing","cn-wulanchabu","eu-central-1"], regions))
 
+        # 澳洲区域关闭，过滤
+        regions = [region for region in regions if region not in ["ap-northeast-2"]]
+        
         for region in regions:
             if "test" in region:
                 continue


### PR DESCRIPTION
1.bpm申请权限流程增加重试&增加超时时间
2.检查ips的时候，缓存中找不到的ip从cmdb中重新找一遍
3. 由于aliyun澳洲中心关闭,但区域列表中还可查询,估过滤掉澳州区域ap-southeast-2