### PR TITLE
修复(exmesg): 修复华为云CES告警稳定性问题

### DIFF
--- a/Connector/pp/mmon/exmesg/c3mc-mon-exmesg-cron
+++ b/Connector/pp/mmon/exmesg/c3mc-mon-exmesg-cron
@@ -8,6 +8,7 @@ use YAML::XS;
 use Encode;
 use DateTime::Format::ISO8601;
 use DateTime::TimeZone;
+use JSON;
 
 =head1 SYNOPSIS
 
@@ -18,17 +19,12 @@ use DateTime::TimeZone;
 sub bj_time
 {
     my $iso8601_str = shift @_;
-
     my $dt = DateTime::Format::ISO8601->parse_datetime($iso8601_str);
-
     $dt->set_time_zone('UTC');
-
     my $bj_time_zone = DateTime::TimeZone->new(name => 'Asia/Shanghai');
     $dt->set_time_zone($bj_time_zone);
-
     return $dt->strftime('%Y-%m-%dT%H:%M:%S.%3N%z');
 }
-
 
 my %task;
 
@@ -44,11 +40,9 @@ $task{nexus} = sub
 
     my @user = `c3mc-app-usrext '$to'`;
     chomp @user;
-
     return unless @user;
 
     $res{to} = \@user;
-    $res{mesg} = "unknown";
     my @mesg;
     push @mesg, "nexus Event";
     push @mesg, "action: $cont->{action}";
@@ -57,7 +51,6 @@ $task{nexus} = sub
     push @mesg, "group: $cont->{component}{group}";
     push @mesg, "name: $cont->{component}{name}";
     push @mesg, "version: $cont->{component}{version}";
-
     $res{mesg} = join "\n", @mesg;
     return \%res;
 };
@@ -73,23 +66,77 @@ $task{default} = sub
 
     my @user = `c3mc-app-usrext '$to'`;
     chomp @user;
-
     return unless @user;
 
     $res{to} = \@user;
+
+    # -----------------------------------------------------------------------
+    # 华为云 CES 告警：提取两个稳定字段传给 exmesg-save
+    #
+    # _ces_stable_key : alarm_name|namespace|metric_name|dimension
+    #                   用于计算 md5 文件名，与 AI 输出完全无关
+    #
+    # _ces_newmesg    : 告警名称/指标名称/资源名称 三行，直接来自原始 JSON
+    #                   用于写 uuid 文件的 newmesg 段，maker 读取生成 desc label
+    #                   desc 稳定 -> fingerprint 稳定 -> 知晓永远有效
+    #
+    # 注意编码：JSON decode_json 返回的字符串是 utf8_flag=ON 的 unicode 字符串
+    # 字段名前缀（"告警名称: " 等）用 Encode::decode('utf8', ...) 统一成 unicode
+    # 最后整体 Encode::encode('utf8', ...) 转成 bytes 传给 save
+    # -----------------------------------------------------------------------
+
+    my $raw = Encode::encode('utf8', $cont->{message} || '');
+    if( $raw =~ /"alarm_status"\s*:/ )
+    {
+        my $alarm = eval{ JSON::decode_json($raw) };
+        if( $alarm )
+        {
+            my $alarm_name   = $alarm->{alarm_name}  || '';
+            my $namespace    = $alarm->{namespace}   || '';
+            my $metric_name  = $alarm->{metric_name} || '';
+            my $dimension    = $alarm->{dimension}   || '';
+
+            my $tv            = $alarm->{template_variable} || {};
+            my $resource_name = $tv->{ResourceName} || '';
+
+            # stable_key：bytes 字符串，用于 md5 计算
+            $res{_ces_stable_key} = join('|', $alarm_name, $namespace, $metric_name, $dimension);
+
+            # alarm_status：直接传给 exmesg-save，不依赖 AI 输出文本判断告警状态
+            # 避免 AI 调用失败时 mesg 里无「告警状态」字段被误判为恢复
+            $res{_ces_alarm_status} = lc( $alarm->{alarm_status} || 'alarm' );
+
+            # newmesg：字段名 decode 成 unicode，与 JSON 返回的 unicode 字段值拼接
+            # 最后整体 encode 成 utf8 bytes
+            my $k1 = Encode::decode('utf8', "\xe5\x91\x8a\xe8\xad\xa6\xe5\x90\x8d\xe7\xa7\xb0: ");
+            my $k2 = Encode::decode('utf8', "\xe6\x8c\x87\xe6\xa0\x87\xe5\x90\x8d\xe7\xa7\xb0: ");
+            my $k3 = Encode::decode('utf8', "\xe8\xb5\x84\xe6\xba\x90\xe5\x90\x8d\xe7\xa7\xb0: ");
+            my @newmesg_lines;
+            push @newmesg_lines, $k1 . $alarm_name    if $alarm_name;
+            push @newmesg_lines, $k2 . $metric_name   if $metric_name;
+            push @newmesg_lines, $k3 . $resource_name if $resource_name;
+            $res{_ces_newmesg} = Encode::encode('utf8', join("\n", @newmesg_lines));
+        }
+    }
+
     delete $cont->{unsubscribe_url};
     my $mesg = YAML::XS::Dump $cont;
 
-    my $tmp = "/tmp/c3mc-mon-exmesg.$$.temp";
+    # AI 整理：只用于飞书通知展示，与 md5/newmesg 计算完全无关
     my $aimsg = `cat $file | /data/Software/mydan/dan/tools/alarm 30 c3mc-mai-bedrock`;
-    $mesg = "下面信息由AI整理生成\n$aimsg" unless $?;
+    # AI 调用成功（$?==0）且输出内容不含 [ERROR] 时才使用 AI 结果
+    # AI 调用失败或返回错误内容时保持原始 YAML，避免因 mesg 缺少「告警状态」字段被 exmesg-save 误判为恢复
+    if( !$? && $aimsg !~ /\[ERROR\]/ )
+    {
+        $mesg = "\xe4\xb8\x8b\xe9\x9d\xa2\xe4\xbf\xa1\xe6\x81\xaf\xe7\x94\xb1AI\xe6\x95\xb4\xe7\x90\x86\xe7\x94\x9f\xe6\x88\x90\n$aimsg";
+    }
 
-    $res{mesg} = Encode::decode( 'utf8', $mesg );
+    $res{mesg} = Encode::decode('utf8', $mesg);
+    $res{call} = "C3\xe6\x8a\xa5\xe5\x91\x8a\xe4\xbf\xa1\xe6\x81\xaf";
 
-    $res{call} = "C3报告信息";
-
-    delete $res{call} if ${mesg} =~ /已恢复/;
-    delete $res{call} if ${mesg} =~ /告警恢复/;
+    my $mesg_bytes = Encode::encode('utf8', $res{mesg});
+    delete $res{call} if $mesg_bytes =~ /\xe5\xb7\xb2\xe6\x81\xa2\xe5\xa4\x8d/;
+    delete $res{call} if $mesg_bytes =~ /\xe5\x91\x8a\xe8\xad\xa6\xe6\x81\xa2\xe5\xa4\x8d/;
 
     return \%res;
 };
@@ -97,7 +144,6 @@ $task{default} = sub
 
 my $datapath = "/data/open-c3-data/monitor-exmesg";
 my ( $error, $fail, $succ ) = grep{ system "mkdir -p '$_'" unless -d $_; 1 }map{ "$datapath/$_" }qw( error fail succ );
-
 
 for my $file ( glob "$datapath/queue/*" )
 {
@@ -128,4 +174,3 @@ for my $file ( glob "$datapath/queue/*" )
         system "mv '$file' '$fail'";
     }
 }
-

--- a/Connector/pp/mmon/exmesg/c3mc-mon-exmesg-maker
+++ b/Connector/pp/mmon/exmesg/c3mc-mon-exmesg-maker
@@ -13,18 +13,53 @@ use Encode;
 
 =cut
 
+# -----------------------------------------------------------------------
+# 修复：只读 "----" 分隔符后面的 newmesg 段，不读全文
+#
+# uuid 文件结构（由 exmesg-save 写入）：
+#   [第一段] AI 整理的完整文本（含当前值、告警时间等动态字段）
+#   ----
+#   [第二段] newmesg：去掉动态字段（当前值/告警时间/告警状态/阈值）后的稳定行
+#
+# 原代码对全文做 @keep 前缀匹配，两段都会命中，导致每个字段重复两次，
+# desc label 变成 "告警名称: x;告警名称: x;指标名称: y;指标名称: y;..."
+#
+# 正确做法：只读第二段（newmesg），该段已排除所有动态字段，
+# 内容稳定，不会因 AI 每次输出格式差异导致 fingerprint 变化。
+# -----------------------------------------------------------------------
 
-my @keep = ('告警名称', '指标名称','当前值','资源名称');
-for my $file ( glob "/data/open-c3-data/monitor-exmesg/uuid/*" )
+my @keep = ('告警名称', '指标名称', '资源名称');
+
+for my $file ( glob "/data/open-c3-data/monitor-exmesg/uuid/*.exmesg" )
 {
+    # 只处理 .exmesg 文件，跳过 .exmesg.del 等
+    next if $file =~ /\.del$/;
+
     my ( $md5 ) = reverse split /\//, $file;
+
     my @cont = `cat '$file'`;
     chomp @cont;
+
+    # 找到 ---- 分隔符的位置，只取后面那段（newmesg）
+    my $sep = 0;
+    my @newmesg_lines;
+    for my $line ( @cont )
+    {
+        if( $line eq '----' )
+        {
+            $sep = 1;
+            next;
+        }
+        push @newmesg_lines, $line if $sep;
+    }
+
+    # 若文件没有 ---- 分隔符（异常情况），回退读全文
+    @newmesg_lines = @cont unless $sep;
 
     my @c;
     for my $k ( @keep )
     {
-        for my $c ( @cont )
+        for my $c ( @newmesg_lines )
         {
             push( @c, $c ) if 0 == index( $c, $k );
         }

--- a/Connector/pp/mmon/exmesg/c3mc-mon-exmesg-save
+++ b/Connector/pp/mmon/exmesg/c3mc-mon-exmesg-save
@@ -46,22 +46,73 @@ for my $m ( @mesg )
     {
          $alarm = 1 if 0 == index( $m, $a )
     }
- 
 }
 
-my $md5 = Digest::MD5->new->add( Encode::encode('utf8', join "x", @newmesg) )->hexdigest;
+# -----------------------------------------------------------------------
+# 华为云 CES 告警：alarm 状态直接从 _ces_alarm_status 判断
+# 不依赖 mesg 文本匹配，避免 AI 调用失败时被误判为恢复导致 uuid 文件错误删除
+# -----------------------------------------------------------------------
+if( defined $data->{_ces_alarm_status} )
+{
+    $alarm = ( $data->{_ces_alarm_status} eq 'alarm' ) ? 1 : 0;
+}
 
-my $dir = "/data/open-c3-data/monitor-exmesg/uuid";
+# -----------------------------------------------------------------------
+# md5 计算
+# 华为云 CES：用 _ces_stable_key（原始 JSON 稳定字段），与 AI 输出无关
+# 其他消息：用 newmesg 文本（原有逻辑）
+# -----------------------------------------------------------------------
+my $md5;
+if( $data->{_ces_stable_key} )
+{
+    $md5 = Digest::MD5->new->add( Encode::encode('utf8', $data->{_ces_stable_key}) )->hexdigest;
+}
+else
+{
+    $md5 = Digest::MD5->new->add( Encode::encode('utf8', join "x", @newmesg) )->hexdigest;
+}
+
+# -----------------------------------------------------------------------
+# newmesg 段内容
+# 华为云 CES：用 _ces_newmesg（原始 JSON 稳定字段，已在 cron 里构造好）
+#   _ces_newmesg 是 Perl unicode 字符串（wide char），写文件时直接 encode utf8
+# 其他消息：用 @newmesg（bytes，直接 encode utf8）
+# -----------------------------------------------------------------------
+my $write_newmesg = sub {
+    my $fh = shift;
+    if( $data->{_ces_newmesg} )
+    {
+        # _ces_newmesg 在 cron 里已经 Encode::encode('utf8') 成 bytes
+        # 经过 YAML roundtrip 后仍是 utf8 bytes，直接 print 不再 encode
+        print $fh $data->{_ces_newmesg} . "\n";
+    }
+    else
+    {
+        # @newmesg 是 bytes，直接 encode utf8（原有逻辑）
+        map{ print $fh Encode::encode('utf8', "$_\n") }@newmesg;
+    }
+};
+
+my $dir      = "/data/open-c3-data/monitor-exmesg/uuid";
 system( "mkdir -p '$dir'" ) unless -d $dir;
-my $file = "$dir/$md5.exmesg";
+my $file     = "$dir/$md5.exmesg";
+my $file_del = "$dir/$md5.exmesg.del";
+
 if( $alarm )
 {
-    open my $H, ">", $file or die "open $file fail: $!";
-    print $H Encode::encode('utf8', $mesg);
-
-    print $H "----\n";
-    map{print $H Encode::encode('utf8', "$_\n") }@newmesg;;
-    close $H;
+    # 顺序保护：恢复消息已先处理（.del 存在），不写 uuid 文件
+    if( -f $file_del )
+    {
+        unlink $file_del;
+    }
+    else
+    {
+        open my $H, ">", $file or die "open $file fail: $!";
+        print $H Encode::encode('utf8', $mesg);
+        print $H "----\n";
+        $write_newmesg->($H);
+        close $H;
+    }
 }
 else
 {
@@ -71,10 +122,10 @@ else
     }
     else
     {
-        open my $H, ">", "$file.del" or die "open $file fail: $!";
+        open my $H, ">", $file_del or die "open $file_del fail: $!";
         print $H Encode::encode('utf8', $mesg);
         print $H "----\n";
-        map{print $H Encode::encode('utf8', "$_\n") }@newmesg;;
+        $write_newmesg->($H);
         close $H;
     }
 }


### PR DESCRIPTION
## 问题

华为云 CES 告警通过 SMN 推送到 Open-C3 后，存在以下问题：

1. AI 输出格式不稳定（字段名大小写、末尾空格），导致 md5 错位，告警无法恢复
2. AI 调用失败时回退原始 YAML，md5 必然不匹配
3. exmesg-maker 读全文导致 desc label 字段重复，fingerprint 不稳定，知晓标识消失
4. AI 调用失败返回 [ERROR] 时被误判为告警恢复，uuid 文件被错误删除

## 修复

对华为云 CES 告警（message 字段含 alarm_status 的 JSON），
直接解析原始 JSON 提取稳定字段，不依赖 AI 输出：

- _ces_stable_key：用于 md5 计算
- _ces_newmesg：用于 uuid 文件 desc 内容
- _ces_alarm_status：用于告警/恢复状态判断

AI 继续用于飞书通知展示，不影响告警状态管理逻辑。